### PR TITLE
Closes two issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Suggests:
     ggplot2,
     tidyr,
     geepack,
-    rmarkdown
+    rmarkdown,
+    future
 VignetteBuilder: knitr
 Encoding: UTF-8
 RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,3 +37,5 @@ Encoding: UTF-8
 RoxygenNote: 6.1.1
 Author: Brandon LeBeau [aut, cre]
 Maintainer: Brandon LeBeau <lebebr01+simglm@gmail.com>
+URL: https://github.com/lebebr01/simglm
+BugReports: https://github.com/lebebr01/simglm/issues

--- a/vignettes/simulation_arguments.Rmd
+++ b/vignettes/simulation_arguments.Rmd
@@ -611,7 +611,7 @@ simulate_fixed(data = NULL, sim_arguments) %>%
 The `replicate_simulation` function first shown in the "tidy_simulation" vignette, can directly allow for the varying of simulation arguments. In order to vary simulation arguments, an additional named list called `vary_arguments` can be added to the simulation arguments passed to the functions. The `vary_arguments` elements of the simulation arguments is a nested named list. Within the named list, the arguments that are wished to be varied are specified by name. For example, a common argument varied is sample size. The following example varies the sample size to return multiple simulated data sets with different sample sizes.
 
 ```{r vary_simulation}
-library(future.apply)
+library(future)
 plan(multiprocess)
 
 sim_arguments <- list(

--- a/vignettes/tidy_simulation.Rmd
+++ b/vignettes/tidy_simulation.Rmd
@@ -302,7 +302,7 @@ The default power parameter values used are: Normal distribution, two-tailed alt
 ```{r replicate_simulation_power_values}
 set.seed(321) 
 
-library(future.apply)
+library(future)
 plan(multiprocess)
 
 sim_arguments <- list(


### PR DESCRIPTION
- Add URL and BugReports to description. 
- Use `library(future)` instead of `library(future.apply)` in vignettes.