### PR TITLE
Fix joining of statistics column

### DIFF
--- a/R/pow_sim.r
+++ b/R/pow_sim.r
@@ -901,10 +901,17 @@ compute_statistics <- function(data, sim_args, power = TRUE,
     precision_computation <- NULL
   }
   
-  statistics <- dplyr::bind_cols(avg_estimates,
-                                 power_computation, 
-                                 type_1_error_computation, 
-                                 precision_computation) 
+  statistics <- dplyr::full_join(
+    avg_estimates,
+    power_computation,
+    by = "term"
+  ) %>% dplyr::full_join(
+    type_1_error_computation,
+    by = "term"
+  ) %>% dplyr::full_join(
+    precision_computation,
+    by = "term"
+  )
   
   select_columns <- rlang::syms(names(statistics)[names(statistics) %ni%
                        regmatches(names(statistics), 


### PR DESCRIPTION
`bind_cols()` creates duplicate `term` columns. `full_join()` instead matches columns by the values of the `term` columns.