### PR TITLE
Updated simulation arguments vignette to introduce the force_equal = TRUE argument

### DIFF
--- a/R/fixef_sim.r
+++ b/R/fixef_sim.r
@@ -12,7 +12,7 @@
 #' @param replace TRUE/FALSE indicating whether levels should be sampled with 
 #'   replacement. Default is TRUE.
 #' @param force_equal TRUE/FALSE indicating if the sample size should be forced
-#'     to be equal. 
+#'     to be equal. Should not be used with the `replace = FALSE` argument.
 #' @param ... Additional parameters passed to the sample function.
 #' @export 
 sim_factor2 <- function(n, levels, var_level = 1, replace = TRUE,

--- a/man/sim_factor2.Rd
+++ b/man/sim_factor2.Rd
@@ -20,7 +20,7 @@ respectively.}
 replacement. Default is TRUE.}
 
 \item{force_equal}{TRUE/FALSE indicating if the sample size should be forced
-to be equal.}
+to be equal. Should not be used with the `replace = FALSE` argument.}
 
 \item{...}{Additional parameters passed to the sample function.}
 }

--- a/vignettes/simulation_arguments.Rmd
+++ b/vignettes/simulation_arguments.Rmd
@@ -135,9 +135,52 @@ Factor variables are generated similarly to ordinal variables with the `sample` 
 
 An additional optional argument is `replace`. The `replace` argument specified whether the sampling is done with or without replacement. The default behavior is to do sampling with replacement. If sampling without replacement is desired set `replace = FALSE`. See `sample` for more details on this argument.
 
-Finally, the probability of selecting each value specified to the `levels` argument is also able to be specified through the `prob` argument. If `prob` is specified, it takes a vector of probabilities that must be the same length as the levels argument. The default behavior is for each value specified with `levels` to be equally likely to be sampled.
+The probability of selecting each value specified to the `levels` argument is also able to be specified through the `prob` argument. If `prob` is specified, it takes a vector of probabilities that must be the same length as the levels argument. The default behavior is for each value specified with `levels` to be equally likely to be sampled.
 
-## Knot Variables
+It is also possible to simulate data from a balanced factorial design by including the `force_equal = TRUE` argument. This argument will cause the `simulate_fixed()` function to produce a data set with an equal number of observations for each level of the factor variable, instead of randomly sampling from the levels. To see the difference, compare the difference between the two following simulations:
+
+```{r unbalanced}
+set.seed(321) 
+
+sim_arguments <- list(
+  formula = y ~ 1 + weight + treat ,
+  fixed = list(weight = list(var_type = 'continuous', dist = 'rgamma', 
+                             shape = 3
+                             ),
+               treat = list(var_type = 'factor', 
+                            levels = c('Treatment A', 'Treatment B', 'Control')
+                            )
+               ),
+  sample_size = 33
+)
+
+unbalanced_data <- simulate_fixed(data = NULL, sim_arguments)
+dplyr::count(unbalanced_data, treat) # unequal number of control and treatment observations
+```
+
+```{r balanced}
+set.seed(321) 
+
+sim_arguments <- list(
+  formula = y ~ 1 + weight + treat ,
+  fixed = list(weight = list(var_type = 'continuous', dist = 'rgamma', 
+                             shape = 3
+                             ),
+               treat = list(var_type = 'factor', 
+                            levels = c('Treatment A', 'Treatment B', 'Control'),
+                            force_equal = TRUE
+                            )
+               ),
+  sample_size = 33
+)
+
+balanced_data <- simulate_fixed(data = NULL, sim_arguments)
+dplyr::count(balanced_data, treat) # equal number of control and treatment observations
+```
+
+Note that the `force_equal = TRUE` argument is incompatible with the `replace = FALSE` option. The `force_equal = TRUE` argument supersedes the `prob` argument - in other words, specifying `force_equal = TRUE` as well as specifying specific sampling probabilities will not cause an error, but doesn't make conceptual sense, and those sampling probabilities will not be reflected in the simulated data.
+
+## Knot Variables 
 
 Knot variables are defined as those that are a prominent point based on a specific spot of another variable. A common example of these types of variables would occur in interrupted time series data, where there is a place in time where the treatment is given after a series of baselines. The place where the treatment is given is the knot location.
 


### PR DESCRIPTION
Updates the vignettes to include an example of using the force_equal = TRUE argument for factor variables